### PR TITLE
Add links to annotations autograders

### DIFF
--- a/Teams/CentralizedAutograder-java.md
+++ b/Teams/CentralizedAutograder-java.md
@@ -2,7 +2,7 @@
 
 [There is also a Python version of this guide](./CentralizedAutograder)
 
-In a [previous guide](./SimpleAutograding-java) we built a basic autograding solution that could automatically run and test your students' assignments. However, there were still some manual steps involved: you needed to navigate to each student's fork of the assignment and kick off the tests manually.
+In a [previous guide](./SimpleAutograding-java) we built a basic autograding solution that could automatically run and test your students' assignments. However, there were still some manual steps involved: you needed to navigate to each student's submission of the assignment and kick off the tests manually.
 
 In this guide, we'll show you how to take it a step further and build a centralised grading server. Your students will be able to submit their assignments to this server, and each submission will automatically kick off the tests, assign a grade, and create a summary report of submissions and grades for you to review.
 
@@ -14,11 +14,11 @@ We assume that your students are learning Java. We'll give an example Java assig
 
 ## Overview of how the solution works
 
-The basic workflow is similar to in the previous guide, but this time you won't need to look at each student's fork individually. Instead, students will submit them to a centralised server, and you can view their code there, or just look at the summary report it will generate.
+The basic workflow is similar to in the previous guide, but this time you won't need to look at each student's submission individually. Instead, students will submit them to a centralised server, and you can view their code there, or just look at the summary report it will generate.
 
 ![](/images/teamsForEducation/centralized-autograder-java/01-solution-overview.png)
 
-After a student forks the assignment, they will be able to write their code, test it on their own, and then submit it when they are satisfied with their answers. 
+After a student starts the assignment, they will be able to write their code, test it on their own, and then submit it when they are satisfied with their answers. 
 
 The grading server will not be visible to students, so they will still not be able to view each other's work or grades.
 
@@ -109,7 +109,7 @@ Take note of the URL, which is based on your team and project name, as we'll nee
 
 ## Setting up the assignment 
 
-Now that we have a server, we need to build the other half: the assignment project for students to fork and submit.
+Now that we have a server, we need to build the other half: the assignment project for students to start and submit.
 
 ### Create a new project 
 
@@ -242,7 +242,7 @@ Fix the subtract function by swapping `b` and `a` as follows and submit it one m
   }
 ```
 
-Finally, change all of the code back to how it was as this is the version that students will fork and we don't want them to have the solutions. Change the ReadyForSubmission=YES line to NO and change the return statements, replacing the  answers with `return = 0` instead.
+Finally, change all of the code back to how it was as this is the version that students will work on and we don't want them to have the solutions. Change the ReadyForSubmission=YES line to NO and change the return statements, replacing the  answers with `return = 0` instead.
 
 ```java
 // ReadyForSubmission=NO
@@ -273,7 +273,7 @@ You can also see `report.md` has been generated, with details of the two submiss
 
 ## Publishing the project for students to use
 
-Once you are happy with the assignment, press the "publish project" button in the top right. Students will get a notification that their homework is ready and be able to create a fork, modify the code, and submit it to the grading server.
+Once you are happy with the assignment, press the "publish project" button in the top right. Students will get a notification that their homework is ready and be able to start the project, modify the code, and submit it to the grading server.
 
 ![](/images/teamsForEducation/centralized-autograder-java/11-publish-asignment.png)
 

--- a/Teams/CentralizedAutograder-java.md
+++ b/Teams/CentralizedAutograder-java.md
@@ -269,6 +269,8 @@ In each of these folders, you can see the code that was submitted.
 
 You can also see `report.md` has been generated, with details of the two submissions (who submitted them and when) and their calculated grades.
 
+If you want to discuss the submitted code with the student, you can navigate to the grading-project submissions page and view the submission in question. From there you can select a piece of code from your student's submission and click on the annotate button to leave a message. This makes it easy to ask for clarification or give advice. You can read more on the annotation feature [here](https://docs.repl.it/Teams/Annotations)
+
 ![](/images/teamsForEducation/centralized-autograder-java/10-java-example-report.png)
 
 ## Publishing the project for students to use

--- a/Teams/CentralizedAutograder.md
+++ b/Teams/CentralizedAutograder.md
@@ -346,6 +346,8 @@ In each of these folders, you can see the code that was submitted.
 
 You can also see `report.md` has been generated, with details of the two submissions (who submitted them and when) and their calculated grades.
 
+If you want to discuss the submitted code with the student, you can navigate to the grading-project submissions page and view the submission in question. From there you can select a piece of code from your student's submission and click on the annotate button to leave a message. This makes it easy to ask for clarification or give advice. You can read more on the annotation feature [here](https://docs.repl.it/Teams/Annotations)
+
 ![](/images/teamsForEducation/centralized-autograder-python/08-report-serverside.png)
 
 ## Publishing the project for students to use

--- a/Teams/CentralizedAutograder.md
+++ b/Teams/CentralizedAutograder.md
@@ -2,7 +2,7 @@
 
 [There is also a Java version of this guide](./CentralizedAutograder-java)
 
-In a [previous guide](./SimpleAutograding) we built a basic autograding solution that could automatically run and test your students' assignments. However, there were still some manual steps involved: you needed to navigate to each student's fork of the assignment and kick off the tests manually.
+In a [previous guide](./SimpleAutograding) we built a basic autograding solution that could automatically run and test your students' assignments. However, there were still some manual steps involved: you needed to navigate to each student's submission of the assignment and kick off the tests manually.
 
 In this guide, we'll show you how to take it a step further and build a centralised grading server. Your students will be able to submit their assignments to this server, and each submission will automatically kick off the tests, assign a grade, and create a summary report of submissions and grades for you to review.
 
@@ -14,11 +14,11 @@ We assume that your students are learning Python. We'll give an example Python a
 
 ## Overview of how the solution works
 
-The basic workflow is similar to in the previous guide, but this time you won't need to look at each student's fork individually. Instead, students will submit them to a centralised server, and you can view their code there, or just look at the summary report it will generate.
+The basic workflow is similar to in the previous guide, but this time you won't need to look at each student's submission individually. Instead, students will submit them to a centralised server, and you can view their code there, or just look at the summary report it will generate.
 
 ![](/images/teamsForEducation/centralized-autograder-python/01-overview-python.png)
 
-After a student forks the assignment, they will be able to write their code, test it on their own, and then submit it when they are satisfied with their answers. 
+After a student starts the assignment, they will be able to write their code, test it on their own, and then submit it when they are satisfied with their answers. 
 
 The grading server will not be visible to students, so they will still not be able to view each other's work or grades.
 
@@ -200,7 +200,7 @@ That's it for our server. Press the `Run` button and your server should start ru
 
 ## Setting up the assignment 
 
-Now that we have a server, we need to build the other half: the assignment project for students to fork and submit.
+Now that we have a server, we need to build the other half: the assignment project for students to start and submit.
 
 ### Create a new project 
 
@@ -321,7 +321,7 @@ def subtract(a, b):
     return a - b
 ```
 
-Finally, change all of the code back to how it was as this is the version that students will fork and we don't want them to have the solutions. Recomment out the `MODE = "SUBMIT"` line and remove the return statements, replacing them with `pass` instead.
+Finally, change all of the code back to how it was as this is the version that students will work on and we don't want them to have the solutions. Recomment out the `MODE = "SUBMIT"` line and remove the return statements, replacing them with `pass` instead.
 
 ```python
 MODE = "TEST"
@@ -350,7 +350,7 @@ You can also see `report.md` has been generated, with details of the two submiss
 
 ## Publishing the project for students to use
 
-Once you are happy with the assignment, press the "publish project" button in the top right. Students will get a notification that their homework is ready and be able to create a fork, modify the code, and submit it to the grading server.
+Once you are happy with the assignment, press the "publish project" button in the top right. Students will get a notification that their homework is ready and be able to start the project, modify the code, and submit it to the grading server.
 
 ![](/images/teamsForEducation/centralized-autograder-python/09-publish-project.png)
 

--- a/Teams/SimpleAutograding-java.md
+++ b/Teams/SimpleAutograding-java.md
@@ -172,6 +172,8 @@ Once your students have each created and submitted the project, you can open eac
 
 If you want, you can simply use the percentage of the tests passed as a grade (for example, our imaginary student would be awarded 50% for passing 1/2 tests), but because you can see exactly what went wrong you can also decide if some tests are more important than others.
 
+You can also select a piece of code from your student's submission and click on the annotate button to leave a message. This makes it easy to ask for clarification or give advice. You can read more on the annotation feature [here](https://docs.repl.it/Teams/Annotations)
+
 While this is a semi-automated solution, you are still required to open each solution manually in order to kick off the tests. In [Creating a centralised grading application with Repl.it](./CentralizedAutograder-java), we show you how to take autograding a step further to avoid this.
 
 ## Conclusion

--- a/Teams/SimpleAutograding-java.md
+++ b/Teams/SimpleAutograding-java.md
@@ -45,7 +45,7 @@ Projects let you create a repl that might have different variants. For example, 
 * Once the project is published, members (students) can only see the project and create their own copy to work on their submission. They cannot edit the main copy.
 * People outside the team cannot see the project at all.
 
-Only admins can see the all forks of a project. This means that students cannot see each other's work, which helps prevent plagiarism.
+Only admins can see all submissions of a project. This means that students cannot see each other's work, which helps prevent plagiarism.
 
 ## Create your first project
 
@@ -134,7 +134,7 @@ Before students can see and submit this homework you need to 'publish' it. Do th
 
 ![](/images/teamsForEducation/simple-autograding-java/07-publish-project.png)
 
-Now slide the button across to 'published' and your students can access the project. They will also get a notification in Repl.it that a new project has been published, and you will similarly see a notification once they fork and submit.
+Now slide the button across to 'published' and your students can access the project. They will also get a notification in Repl.it that a new project has been published, and you will similarly see a notification once they start and submit.
 
 ![](/images/teamsForEducation/simple-autograding-java/08-edit-project-to-published.png)
 
@@ -160,7 +160,7 @@ Back in your teacher account, navigate to the team dashboard and find the releva
 
 ![](/images/teamsForEducation/simple-autograding-java/11-view-submissions.png)
 
-You'll be taken to a page where you can see all versions of this assignment. In this example, we only see one (from the test we created above). Once your students start forking the assignment you'll see more, and each of them will be labeled as "submitted" or "unsubmitted", depending on whether or not the student has pressed the `submit` button.
+You'll be taken to a page where you can see all versions of this assignment. In this example, we only see one (from the test we created above). Once your students start the assignment you'll see more, and each of them will be labeled as "submitted" or "unsubmitted", depending on whether or not the student has pressed the `submit` button.
 
 ![](/images/teamsForEducation/simple-autograding-java/12-projects-submisions-page.png)
 

--- a/Teams/SimpleAutograding.md
+++ b/Teams/SimpleAutograding.md
@@ -176,6 +176,8 @@ Open the submission, open the command shell and run `pytest` again. You should s
 
 Once your students have each started and submitted an assignment, you can open each of the students' submissions and run `pytest` to easily see a summary of how many tests they passed and what mistakes they made. If you want, you can simply use the percentage of the tests passed as a grade (for example, our imaginary student would be awarded 50% for passing 1/2 tests), but because you can see exactly what went wrong you can also decide if some tests are more important than others.
 
+You can also select a piece of code from your student's submission and click on the annotate button to leave a message. This makes it easy to ask for clarification or give advice. You can read more on the annotation feature [here](https://docs.repl.it/Teams/Annotations)
+
 While this is a semi-automated solution, you are still required to open each solution manually in order to kick off the tests. In [Creating a centralised grading application with Repl.it](./CentralizedAutograder), we show you how to take autograding a step further to avoid this.
 
 ## Conclusion

--- a/Teams/SimpleAutograding.md
+++ b/Teams/SimpleAutograding.md
@@ -33,7 +33,7 @@ Before we get started with building the autograded solution, you should have a g
 
 If you're using Teams for Education, you should make sure that you're added as an 'owner' or 'admin' while all of your students are 'members'.
 
-This means that you will be able to see all submissions (called 'forks') of the homework, while your students will only be able to see the skeleton (or 'project' as described below) that you provide.
+This means that you will be able to see all submissions of the homework, while your students will only be able to see the skeleton (or 'project' as described below) that you provide.
 
 ![](/images/teamsForEducation/simple-autograding-python/01-manage-team.png)
 
@@ -45,11 +45,11 @@ Projects let you create a repl that might have different variants. For example, 
 * Once the project is published, members (students) can only see the project and create their own copy to work on their submission. They cannot edit the main copy.
 * People outside the team cannot see the project at all.
 
-Only admins can see the all forks of a project. This means that students cannot see each other's work, which helps prevent plagiarism.
+Only admins can see all submissions of a project. This means that students cannot see each other's work, which helps prevent plagiarism.
 
 ## Create your first project
 
-Create a project for the homework assignment you want to prepare and add some details to help you and your students identify it. You can also specify what programming language to use. In this exampe, we'll use Python.
+Create a project for the homework assignment you want to prepare and add some details to help you and your students identify it. You can also specify what programming language to use. In this example, we'll use Python.
 
 ![](/images/teamsForEducation/simple-autograding-python/02-create-project.png)
 
@@ -142,7 +142,7 @@ Before students can see and submit this homework you need to 'publish' it. Do th
 
 ![](/images/teamsForEducation/simple-autograding-python/09-publish-project-button.png)
 
-Now slide the button across to 'published' and your students can access the project. They will also get a notification in Repl.it that a new project has been published, and you will similarly see a notification once they fork and submit.
+Now slide the button across to 'published' and your students can access the project. They will also get a notification in Repl.it that a new project has been published, and you will similarly see a notification once they start and submit.
 
 ![](/images/teamsForEducation/simple-autograding-python/10-publish-project-slider.png)
 
@@ -162,19 +162,19 @@ Once the student is satisfied, they can press the `submit` button in the top rig
 
 ## Viewing all submissions as a teacher
 
-Back in your teacher account, navigate to the team dashboard and find the relevant project. Press the `View forks` button.
+Back in your teacher account, navigate to the team dashboard and find the relevant project. Press the `View submissions` button.
 
 ![](/images/teamsForEducation/simple-autograding-python/13-view-submissions.png)
 
-You'll be taken to a page where you can see all versions of this assignment. In this example, we only see one (from the test we created above). Once your students start forking the assignment you'll see more, and each of them will be labeled as "submitted" or "unsubmitted", depending on whether or not the student has pressed the `submit` button.
+You'll be taken to a page where you can see all versions of this assignment. In this example, we only see one (from the test we created above). Once your students start the assignment you'll see more, and each of them will be labeled as "submitted" or "unsubmitted", depending on whether or not the student has pressed the `submit` button.
 
 ![](/images/teamsForEducation/simple-autograding-python/14-submissions-page.png)
 
-Open the fork, open the command shell and run `pytest` again. You should see one test pass and one fail. The subtract function is calculating `2-4` instead of `4-2` and getting the wrong answer.
+Open the submission, open the command shell and run `pytest` again. You should see one test pass and one fail. The subtract function is calculating `2-4` instead of `4-2` and getting the wrong answer.
 
 ![](/images/teamsForEducation/simple-autograding-python/15-test-submissions.png)
 
-Once your students have each created a fork and submitted an assignment, you can open each of the students' forks and run `pytest` to easily see a summary of how many tests they passed and what mistakes they made. If you want, you can simply use the percentage of the tests passed as a grade (for example, our imaginary student would be awarded 50% for passing 1/2 tests), but because you can see exactly what went wrong you can also decide if some tests are more important than others.
+Once your students have each started and submitted an assignment, you can open each of the students' submissions and run `pytest` to easily see a summary of how many tests they passed and what mistakes they made. If you want, you can simply use the percentage of the tests passed as a grade (for example, our imaginary student would be awarded 50% for passing 1/2 tests), but because you can see exactly what went wrong you can also decide if some tests are more important than others.
 
 While this is a semi-automated solution, you are still required to open each solution manually in order to kick off the tests. In [Creating a centralised grading application with Repl.it](./CentralizedAutograder), we show you how to take autograding a step further to avoid this.
 


### PR DESCRIPTION
- Changed references of "fork" to "start project" in all four autograder tutorials 
- Add paragraphs linking to annotations in all four autograder tutorials